### PR TITLE
Change the `fuzzy_match` function to use the `IntoIterator` trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub fn fuzzy_match<'a, T, It>(needle: &str, haystack: It) -> Option<T>
 ///
 /// let haystack = vec![("rust", 0), ("java", 1), ("lisp", 2)];
 /// // Search with Levenshtein first, then Sorensen-Dice.
-/// assert_eq!(Some(0), fuzzy_match_with_algorithms::<_, Levenshtein, SorensenDice>("bust", haystack));
+/// assert_eq!(Some(0), fuzzy_match_with_algorithms::<_, Levenshtein, SorensenDice, _>("bust", haystack));
 /// ```
 /// 
 /// # Panics


### PR DESCRIPTION
I made the `fuzzy_match` function to use `IntoIterator` instead of forcing it to be a vec, with this you can also use a Slice.

At the moment this is a breaking change as I need to add some more type parameters